### PR TITLE
PUSH/PULL example + a couple tiny things.

### DIFF
--- a/spec/socket_spec.rb
+++ b/spec/socket_spec.rb
@@ -343,11 +343,6 @@ module ZMQ
           it "should return an FD as a positive integer" do
             socket.getsockopt(ZMQ::FD).should be_a(Fixnum)
           end
-
-          it "should return a valid FD" do
-            pending "This causes a too many open files error"
-            #lambda { IO.new(socket.getsockopt(ZMQ::FD)).close }.should_not raise_exception(Errno::EBADF)
-          end
         end
 
         context "using option ZMQ::EVENTS" do


### PR DESCRIPTION
Included here are some initial PUSH/PULL specs.

One of the specs should fail,  when using nonblocking in the send. I think this may be a bug with ffi-rzmq, but I'm not sure. If you know off the top of your head that'd be great, if not, I'll check it out this weekend when I have time.
