### PR TITLE
Fix for ubuntu 10.10 / libzmq 2.10

### DIFF
--- a/spec/socket_spec.rb
+++ b/spec/socket_spec.rb
@@ -343,11 +343,6 @@ module ZMQ
           it "should return an FD as a positive integer" do
             socket.getsockopt(ZMQ::FD).should be_a(Fixnum)
           end
-
-          it "should return a valid FD" do
-            pending "This causes a too many open files error"
-            #lambda { IO.new(socket.getsockopt(ZMQ::FD)).close }.should_not raise_exception(Errno::EBADF)
-          end
         end
 
         context "using option ZMQ::EVENTS" do


### PR DESCRIPTION
So, I recently switched from OSX to Ubuntu (got a new Thinkpad!)  and realized that by default on Ubuntu libzmq installs itself to a location ffi-rzmq doesn't check. This patch fixes that up.

Also, I've noticed some HUGE problems on linux. Basically, calling receive on a socket blocks all running ruby threads (1.9.2). Any idea why that might be?
