### PR TITLE
Windows compatibility: :size_t strikes back

### DIFF
--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -144,7 +144,7 @@ module ZMQ
     def getsockopt option_name
       begin
         option_value = FFI::MemoryPointer.new :pointer
-        option_length = FFI::MemoryPointer.new :size_t
+        option_length = FFI::MemoryPointer.new(:size_t) rescue FFI::MemoryPointer.new(:ulong)
 
         unless [
           RCVMORE, HWM, SWAP, AFFINITY, RATE, RECOVERY_IVL, MCAST_LOOP, IDENTITY,


### PR DESCRIPTION
We redefine :size_t as :ulong inside modules LibC and LibZMQ, but core FFI still does not recognize this type under Windows. So, any place you use :size_t, you have to rescue for "Typedef not found" exception.

Alternatively, core FFI may be extended to recognize :size_t as :ulong under Windows, but I'm not really sure how to go about this. 
