### PR TITLE
change to library search paths on Mac OSX

### DIFF
--- a/lib/ffi-rzmq/wrapper.rb
+++ b/lib/ffi-rzmq/wrapper.rb
@@ -22,7 +22,7 @@ end # module LibC
 module LibZMQ
   extend FFI::Library
   LINUX = ["libzmq", "/usr/local/lib/libzmq", "/usr/local/lib/libzmq.so", "/opt/local/lib/libzmq"]
-  OSX = ["libzmq", "/usr/local/lib/libzmq", "/opt/local/lib/libzmq"]
+  OSX = ["libzmq", "/usr/local/lib/libzmq.dynlib", "/opt/local/lib/libzmq.dynlib"]
   WINDOWS = []
   ffi_lib(LINUX + OSX + WINDOWS)
   


### PR DESCRIPTION
adjusted library paths for OSX, suffix processing not performed on full paths

suffix and prefix processing are done for simple library names (e.g. "libzmq")
and if DYLD_LIBRARY_PATH is set FFI will find the library.  If DYLD_LIBRARY_PATH
is not set, FFI won't find library with simple name nor with the full paths
without extensions.
