### PR TITLE
should find libzmq library on OS X automatically

### DIFF
--- a/lib/ffi-rzmq/wrapper.rb
+++ b/lib/ffi-rzmq/wrapper.rb
@@ -21,11 +21,9 @@ end # module LibC
 
 module LibZMQ
   extend FFI::Library
-  LINUX = ["libzmq", "/usr/local/lib/libzmq", "/usr/local/lib/libzmq.so", "/opt/local/lib/libzmq"]
-  OSX = ["libzmq", "/usr/local/lib/libzmq.dylib", "/opt/local/lib/libzmq.dylib"]
-  WINDOWS = []
-  ffi_lib(LINUX + OSX + WINDOWS)
-  
+  ZMQ_LIB_PATHS = %w{/usr/local/lib /opt/local/lib}.map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
+  ffi_lib(%w{libzmq} + ZMQ_LIB_PATHS)
+
   # Size_t not working properly on Windows
   find_type(:size_t) rescue typedef(:ulong, :size_t)
 


### PR DESCRIPTION
fff-rzmq doesn't find the zmq library if it's not in the default library load path.

supplied patch fixes this problem.
