### PR TITLE
Multipart support

### DIFF
--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -283,7 +283,7 @@ module ZMQ
     result_code
   end
 
-  # Send a sequence of messages as a multipart message out of the +parts+
+  # Send a sequence of strings as a multipart message out of the +parts+
   # passed in for transmission. Every element of +parts+ should be
   # a String.
   #
@@ -291,12 +291,13 @@ module ZMQ
   #
   # Raises the same exceptions as Socket#send.
   #
-  def send_multipart parts, flags = 0
-    return [] if !parts || parts.empty?
+  def send_strings parts, flags = 0
+    return false if !parts || parts.empty?
 
     parts[0...-1].each do |part|
-      send_string part, flags | ZMQ::SNDMORE
+      return false unless send_string part, flags | ZMQ::SNDMORE
     end
+
     send_string parts[-1], flags
   end
 
@@ -374,13 +375,13 @@ module ZMQ
     end
   end
 
-  # Receive a multipart message as a list of messages.
+  # Receive a multipart message as a list of strings.
   #
   # +flags+ may be ZMQ::NOBLOCK.
   #
   # Raises the same exceptions as Socket#recv.
   #
-  def recv_multipart flags = 0
+  def recv_strings flags = 0
     parts = []
     parts << recv_string(flags)
     parts << recv_string(flags) while more_parts?

--- a/spec/multipart_spec.rb
+++ b/spec/multipart_spec.rb
@@ -27,11 +27,11 @@ module ZMQ
         it "should be delivered between REQ and REP" do
           req_data, rep_data = [ "1", "2" ], [ "2", "3" ]
 
-          @req.send_multipart(req_data)
-          @rep.recv_multipart.should == req_data
+          @req.send_strings(req_data)
+          @rep.recv_strings.should == req_data
 
-          @rep.send_multipart(rep_data)
-          @req.recv_multipart.should == rep_data
+          @rep.send_strings(rep_data)
+          @req.recv_strings.should == rep_data
         end
       end
 
@@ -58,9 +58,9 @@ module ZMQ
           req_data, rep_data = "hello", [ @req.identity, "", "ok" ]
 
           @req.send_string(req_data)
-          @rep.recv_multipart.should == [ @req.identity, "", "hello" ]
+          @rep.recv_strings.should == [ @req.identity, "", "hello" ]
 
-          @rep.send_multipart(rep_data)
+          @rep.send_strings(rep_data)
           @req.recv_string.should == rep_data.last
         end
       end


### PR DESCRIPTION
I’ve made a patch which allows to send and receieve multipart messages. It is very comfortable at development of ØMQ-based applications and I’m wondered why this feature was absent.

``` ruby
# sure, flags may be passed at last argument
socket1.send_multipart([client_id, '', 'data'])
message = socket2.recv_multipart
```

Please, approve it! ☺
