### PR TITLE
give device thread a chance to actually set up the device. fixes #26

### DIFF
--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -15,6 +15,7 @@ module ZMQ
         front.bind(@front_addr)
         Device.new(ZMQ::STREAMER, back, front)
       end
+      sleep 0.5
     end
     
     it "should create a streamer device without error given valid opts" do


### PR DESCRIPTION
The device test problem described in #26 seems to be a timing issue.

This commit resolves the problem on my machine.
