### PR TITLE
gem install doesn't work correctly by default when ZeroMQ is installed with brew

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -107,6 +107,8 @@ I highly recommend visiting the Learn Ruby 0mq project for a bunch of good code 
 The ZeroMQ library must be installed on your system in a well-known location
 like /usr/local/lib. This is the default for new ZeroMQ installs.
 
+If you have installed ZeroMQ using brew, you need to `brew link zeromq` before installing this gem.
+
 Future releases may include the library as a C extension built at
 time of installation.
 

--- a/lib/ffi-rzmq/wrapper.rb
+++ b/lib/ffi-rzmq/wrapper.rb
@@ -21,7 +21,7 @@ end # module LibC
 
 module LibZMQ
   extend FFI::Library
-  ZMQ_LIB_PATHS = %w{/usr/local/lib /opt/local/lib}.map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
+  ZMQ_LIB_PATHS = %w{/usr/local/lib /opt/local/lib /usr/local/homebrew/lib}.map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
   ffi_lib(%w{libzmq} + ZMQ_LIB_PATHS)
 
   # Size_t not working properly on Windows


### PR DESCRIPTION
if using brew on OS X, `brew install zeromq` and then `brew link zeromq`
will put the libs in /usr/local/homebrew/lib
