### PR TITLE
Make device_spec.rb exit cleanly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.rbc
 *.swp
 pkg
+.redcar/

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,11 @@ namespace :win do
   end
 end
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec
+
 Bones {
   name 'ffi-rzmq'
   authors 'Chuck Remes'

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -55,7 +55,7 @@ module ZMQ
 
 
     context "when allocating a socket" do
-      it "should raise a ZMQ::SocketError exception when allocation fails" do
+      it "should raise a ZMQ::ContextError exception when allocation fails" do
         ctx = spec_ctx
         LibZMQ.stub!(:zmq_socket => nil)
         lambda { ctx.socket(ZMQ::REQ) }.should raise_error(ZMQ::ContextError)

--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -7,66 +7,86 @@ if version2?
     describe Device do
       include APIHelper
 
+      before(:each) do
+        @ctx = Context.new
+      end
+
+      after(:each) do
+        @ctx.terminate
+      end
+      
       def create_streamer
         @back_addr  = "tcp://127.0.0.1:#{random_port}"
         @front_addr = "tcp://127.0.0.1:#{random_port}"
         Thread.new do
-          back  = SPEC_CTX.socket(ZMQ::PULL)
+          back  = @ctx.socket(ZMQ::PULL)
           back.bind(@back_addr)
-          front = SPEC_CTX.socket(ZMQ::PUSH)
+          front = @ctx.socket(ZMQ::PUSH)
           front.bind(@front_addr)
           Device.new(ZMQ::STREAMER, back, front)
+          back.close
+          front.close
         end
         sleep 0.5
       end
-
+      
       it "should create a streamer device without error given valid opts" do
         create_streamer
       end
-
+      
       it "should be able to send messages through the device" do
         create_streamer
-
-        pusher = SPEC_CTX.socket(ZMQ::PUSH)
+      
+        pusher = @ctx.socket(ZMQ::PUSH)
         pusher.connect(@back_addr)
-        puller = SPEC_CTX.socket(ZMQ::PULL)
+        puller = @ctx.socket(ZMQ::PULL)
         puller.connect(@front_addr)
-
+      
         pusher.send_string("hello")
         sleep 0.5
         res = ''
         rc = puller.recv_string(res, ZMQ::NOBLOCK)
         res.should == "hello"
+        
+        pusher.close
+        puller.close
+        sleep 0.5
       end
-
+      
       it "should raise an ArgumentError when trying to pass non-socket objects into the device" do
         lambda {
           Device.new(ZMQ::STREAMER, 1,2)
         }.should raise_exception(ArgumentError)
       end
-
+      
       it "should be able to create a forwarder device without error" do
         back_addr  = "tcp://127.0.0.1:#{random_port}"
         front_addr = "tcp://127.0.0.1:#{random_port}"
         Thread.new do
-          back  = SPEC_CTX.socket(ZMQ::SUB)
+          back  = @ctx.socket(ZMQ::SUB)
           back.bind(back_addr)
-          front = SPEC_CTX.socket(ZMQ::PUB)
+          front = @ctx.socket(ZMQ::PUB)
           front.bind(front_addr)
           Device.new(ZMQ::FORWARDER, back, front)
+          back.close
+          front.close
         end
+        sleep 0.5
       end
-
+      
       it "should be able to create a queue device without error" do
         back_addr  = "tcp://127.0.0.1:#{random_port}"
         front_addr = "tcp://127.0.0.1:#{random_port}"
         Thread.new do
-          back  = SPEC_CTX.socket(ZMQ::ROUTER)
+          back  = @ctx.socket(ZMQ::ROUTER)
           back.bind(back_addr)
-          front = SPEC_CTX.socket(ZMQ::DEALER)
+          front = @ctx.socket(ZMQ::DEALER)
           front.bind(front_addr)
           Device.new(ZMQ::QUEUE, back, front)
+          back.close
+          front.close
         end
+        sleep 0.5
       end
     end
   end

--- a/spec/socket_spec.rb
+++ b/spec/socket_spec.rb
@@ -21,7 +21,7 @@ module ZMQ
           sock = nil
           lambda { sock = Socket.new(@ctx.pointer, socket_type) }.should_not raise_error
           sock.close
-        end
+        end        
       end # each socket_type
 
       it "should set the :socket accessor to the raw socket allocated by libzmq" do


### PR DESCRIPTION
Made device_spec.rb exit clearly by closing sockets and terminating contexts.
