### PR TITLE
Look for libzmq inside of the right paths

### DIFF
--- a/lib/ffi-rzmq/libzmq.rb
+++ b/lib/ffi-rzmq/libzmq.rb
@@ -12,7 +12,7 @@ module ZMQ
       inside_gem = File.join(File.dirname(__FILE__), '..', '..', 'ext')
       lib_paths  = ['/usr/local/lib', '/opt/local/lib', '/usr/local/homebrew/lib',
                     '/usr/lib']
-      lib_paths.map!{|path| path + "64"} if FFI::Platform::ARCH == 'x86_64'
+      lib_paths << '/usr/lib64' if FFI::Platform::ARCH == 'x86_64'
 
       ZMQ_LIB_PATHS = [inside_gem, *lib_paths].map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
       ffi_lib(ZMQ_LIB_PATHS + %w{libzmq})


### PR DESCRIPTION
Take host architecture into consideration while looking for libzmq.
The previous code didn't work on 32bit linux systems since it looked only inside of `/usr/lib64`.

I have no access to a OSX system, I hope I didn't break anything with this change.
