### PR TITLE
raise LoadError instead of calling 'exit'

### DIFF
--- a/lib/ffi-rzmq/libzmq.rb
+++ b/lib/ffi-rzmq/libzmq.rb
@@ -19,7 +19,7 @@ module ZMQ
       STDERR.puts "If this is a Windows platform, make sure libzmq.dll is on the PATH."
       STDERR.puts "For non-Windows platforms, make sure libzmq is located in this search path:"
       STDERR.puts ZMQ_LIB_PATHS.inspect
-      exit 255
+      raise LoadError, "The libzmq library (or DLL) could not be found"
     end
 
     # Size_t not working properly on Windows
@@ -194,8 +194,7 @@ module ZMQ
   unless LibZMQ.version2? || LibZMQ.version3?
     hash = LibZMQ.version
     version = "#{hash[:major]}.#{hash[:minor]}.#{hash[:patch]}"
-    STDERR.puts "Unable to load this gem. The libzmq version #{version} is incompatible with ffi-rzmq."
-    exit 255
+    raise LoadError, "The libzmq version #{version} is incompatible with ffi-rzmq."
   end
 
 end # module ZMQ


### PR DESCRIPTION
The decision to exit should be up to the consumer of the library, not the library itself, I think.

The specific case is that I have unit tests that call plugins that use ffi-rzmq. When libzmq is not found, the entire test suite exits early because ffi-rzmq chooses to call exit. Instead, I would prefer to catch LoadError and skip such related tests. In other cases, I would prefer to report an error  instead of exiting.
