### PR TITLE
Update lib/ffi-rzmq.rb

### DIFF
--- a/lib/ffi-rzmq.rb
+++ b/lib/ffi-rzmq.rb
@@ -1,4 +1,3 @@
-
 module ZMQ
 
   # :stopdoc:
@@ -64,9 +63,7 @@ end  # module ZMQ
 # some code is conditionalized based upon what ruby engine we are
 # executing
 
-RBX = defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /rbx/ ? true : false
-
-require 'ffi' unless RBX
+require 'ffi'
 
 # the order of files is important
 #%w(wrapper zmq exceptions context message socket poll_items poll device).each do |file|


### PR DESCRIPTION
This code should still require 'ffi' on Rubinius. We should not have
built in the assumption that the FFI constant would be available without
a require. Doing so makes it difficult for us to change how that constant
is made available. We're working on supporting the ruby-ffi gem now and
hiding our native implementation.
