### PR TITLE
Fix unbind and disconnect arguments

### DIFF
--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -703,7 +703,7 @@ module ZMQ
       # Disconnect the socket from the given +endpoint+.
       #
       def disconnect(endpoint)
-        LibZMQ.zmq_disconnect(endpoint)
+        LibZMQ.zmq_disconnect(socket, endpoint)
       end
       
       # Version3 only
@@ -711,7 +711,7 @@ module ZMQ
       # Unbind the socket from the given +endpoint+.
       #
       def unbind(endpoint)
-        LibZMQ.zmq_unbind(endpoint)
+        LibZMQ.zmq_unbind(socket, endpoint)
       end
 
 


### PR DESCRIPTION
Both need to pass the socket as the first argument.

This fixes #76.
