### PR TITLE
Fix Poller#to_s method

### DIFF
--- a/lib/ffi-rzmq/poll.rb
+++ b/lib/ffi-rzmq/poll.rb
@@ -127,7 +127,7 @@ module ZMQ
       @poll_items.delete(pollable)
     end
 
-    def to_s inspect; end
+    def to_s; inspect; end
 
     private
 


### PR DESCRIPTION
I've added missing semicolon to `Poller#to_s` method.
