### PR TITLE
Update ZMQ package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_install: sudo apt-get install libzmq-dev
+before_install: sudo apt-get install libzmq3-dev
 script: bundle exec rspec
 language: ruby
 rvm:


### PR DESCRIPTION
Travis CI updated the ZMQ package to use the latest version (3.2.2). The `libzmq-dev` package actually fails to install since a few days, but the `libzmq3-dev` package works fine.
