### PR TITLE
ZMQ::Socket#getsockopt: add support for LAST_ENDPOINT and MULTICAST_HOPS

### DIFF
--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -731,10 +731,14 @@ module ZMQ
         # integer options
         [RECONNECT_IVL_MAX, RCVHWM, SNDHWM, RATE, RECOVERY_IVL, SNDBUF, RCVBUF, IPV4ONLY,
           ROUTER_BEHAVIOR, TCP_KEEPALIVE, TCP_KEEPALIVE_CNT,
-          TCP_KEEPALIVE_IDLE, TCP_KEEPALIVE_INTVL, TCP_ACCEPT_FILTER].each { |option| @option_lookup[option] = 0 }
-          
+          TCP_KEEPALIVE_IDLE, TCP_KEEPALIVE_INTVL, TCP_ACCEPT_FILTER, MULTICAST_HOPS
+        ].each { |option| @option_lookup[option] = 0 }
+
         # long long options
         [MAXMSGSIZE].each { |option| @option_lookup[option] = 1 }
+
+        # string options
+        [LAST_ENDPOINT].each { |option| @option_lookup[option] = 2 }
       end
 
       # these finalizer-related methods cannot live in the CommonSocketBehavior

--- a/spec/socket_spec.rb
+++ b/spec/socket_spec.rb
@@ -268,7 +268,17 @@ module ZMQ
             end
           end # context using option ZMQ::IPV4ONLY
 
-
+          context "using option ZMQ::LAST_ENDPOINT" do
+            it "should return last enpoint" do
+              random_port = bind_to_random_tcp_port(socket, max_tries = 500)
+              array = []
+              rc = socket.getsockopt(ZMQ::LAST_ENDPOINT, array)
+              ZMQ::Util.resultcode_ok?(rc).should == true
+              endpoint_regex = %r{\Atcp://(.*):(\d+)\0\z}
+              array[0].should =~ endpoint_regex
+              Integer(array[0][endpoint_regex, 2]).should == random_port
+            end
+          end
         end # version2? if/else block
 
 


### PR DESCRIPTION
This only adds the behavior only if libzmq3 is used (not version 2).
