### PR TITLE
Add Ruby 2.0.0 to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
+  - 2.0.0
   - ruby-head
   - jruby-18mode
   - jruby-19mode


### PR DESCRIPTION
Ruby 2.0.0 is stable and the specs are passing.
