### PR TITLE
Track pid in Context and Socket finalizers

### DIFF
--- a/lib/ffi-rzmq/context.rb
+++ b/lib/ffi-rzmq/context.rb
@@ -149,15 +149,15 @@ module ZMQ
     private
 
     def define_finalizer
-      ObjectSpace.define_finalizer(self, self.class.close(@context))
+      ObjectSpace.define_finalizer(self, self.class.close(@context, Process.pid))
     end
 
     def remove_finalizer
       ObjectSpace.undefine_finalizer self
     end
 
-    def self.close context
-      Proc.new { LibZMQ.zmq_term context unless context.null? }
+    def self.close context, pid
+      Proc.new { LibZMQ.zmq_term context if !context.null? && Process.pid == pid }
     end
   end
 

--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -629,16 +629,16 @@ module ZMQ
       # module; they *must* be in the class definition directly
 
       def define_finalizer
-        ObjectSpace.define_finalizer(self, self.class.close(@socket))
+        ObjectSpace.define_finalizer(self, self.class.close(@socket, Process.pid))
       end
 
       def remove_finalizer
         ObjectSpace.undefine_finalizer self
       end
 
-      def self.close socket
+      def self.close socket, pid
         Proc.new do
-          LibZMQ.zmq_close(socket) if socket && !socket.null?
+          LibZMQ.zmq_close(socket) if socket && !socket.nil? && Process.pid == pid
         end
       end
     end # class Socket for version2
@@ -745,15 +745,15 @@ module ZMQ
       # module; they *must* be in the class definition directly
 
       def define_finalizer
-        ObjectSpace.define_finalizer(self, self.class.close(@socket))
+        ObjectSpace.define_finalizer(self, self.class.close(@socket, Process.pid))
       end
 
       def remove_finalizer
         ObjectSpace.undefine_finalizer self
       end
 
-      def self.close socket
-        Proc.new { LibZMQ.zmq_close socket }
+      def self.close socket, pid
+        Proc.new { LibZMQ.zmq_close socket if Process.pid == pid }
       end
     end # Socket for version3
   end # LibZMQ.version3?

--- a/spec/socket_spec.rb
+++ b/spec/socket_spec.rb
@@ -60,6 +60,13 @@ module ZMQ
         sock = Socket.new(@ctx.pointer, ZMQ::REQ)
         sock.close
       end
+
+      it "should track pid in finalizer so subsequent fork will not segfault" do
+        sock = Socket.new(@ctx.pointer, ZMQ::REQ)
+        pid = fork { }
+        Process.wait(pid)
+        sock.close
+      end
     end # context initializing
 
 


### PR DESCRIPTION
If a socket is created prior to fork then the reference to the socket (and the context) will carry forward to the child process.  When the child process exits it will try to finalize the socket from the parent and a segfault results:

```
Assertion failed: ok (mailbox.cpp:84)
Abort trap: 6
```

Looks like they ran into the same thing on the perl wrapper and they fixed the issue by tracking the pid where the socket/context is created.  Only the original process will finalize the object.  See: https://github.com/lestrrat/ZeroMQ-Perl/issues/42

In some experiments this works mostly but causes something to hang sporadically.  Perhaps if the child exits prior to the parent the child is still waiting for the parent to finalize the socket and context... I don't know and ran out of time to investigate.
