### PR TITLE
Fix ordering issue of ZeroMQ path discovery

### DIFF
--- a/lib/ffi-rzmq/libzmq.rb
+++ b/lib/ffi-rzmq/libzmq.rb
@@ -13,9 +13,9 @@ module ZMQ
       local_path = FFI::Platform::IS_WINDOWS ? ENV['PATH'].split(';') : ENV['PATH'].split(':')
 
       # Search for libzmq in the following order...
-      ZMQ_LIB_PATHS = [inside_gem] + local_path + [
+      ZMQ_LIB_PATHS =([inside_gem] + local_path + [
         '/usr/local/lib', '/opt/local/lib', '/usr/local/homebrew/lib', '/usr/lib64'
-      ].map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
+      ]).map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
       ffi_lib(ZMQ_LIB_PATHS + %w{libzmq})
     rescue LoadError
       if ZMQ_LIB_PATHS.any? {|path|


### PR DESCRIPTION
There is issue in ZeroMQ library path discovery process.

The `map` method goes **before**  `+` of between `Arrays`. 

So we have no chance to load `ZeroMQ` shared library from a lot of places.

ZMQ_LIB_PATHS (after `+` and `map`)

``` ruby
["/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/ffi-rzmq-1.0.2/lib/ffi-rzmq/../../ext",
 "/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bin",
 "/opt/boxen/rbenv/versions/2.0.0-p247/bin",
 "/opt/boxen/rbenv/libexec",
 "/opt/boxen/rbenv/plugins/ruby-build/bin",
 "bin",
 "/opt/boxen/rbenv/shims",
 "/opt/boxen/rbenv/bin",
 "/opt/boxen/bin",
 "/opt/boxen/homebrew/bin",
 "/opt/boxen/homebrew/sbin",
 "/usr/bin",
 "/bin",
 "/usr/sbin",
 "/sbin",
 "/usr/local/bin",
 "/opt/X11/bin",
 "/usr/texbin",
 "/usr/local/lib/libzmq.dylib",
 "/opt/local/lib/libzmq.dylib",
 "/usr/local/homebrew/lib/libzmq.dylib",
 "/usr/lib64/libzmq.dylib"]
```
