### PR TITLE
Improve rescue of ZeroMQ discovery

### DIFF
--- a/lib/ffi-rzmq/libzmq.rb
+++ b/lib/ffi-rzmq/libzmq.rb
@@ -17,9 +17,8 @@ module ZMQ
         '/usr/local/lib', '/opt/local/lib', '/usr/local/homebrew/lib', '/usr/lib64'
       ].map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
       ffi_lib(ZMQ_LIB_PATHS + %w{libzmq})
-    rescue LoadError
-      if ZMQ_LIB_PATHS.any? {|path|
-        File.file? File.join(path, "libzmq.#{FFI::Platform::LIBSUFFIX}")}
+    rescue LoadError => e
+      if ZMQ_LIB_PATHS.any? {|path| File.file?(path) } 
         warn "Unable to load this gem. The libzmq library exists, but cannot be loaded."
         warn "If this is Windows:"
         warn "-  Check that you have MSVC runtime installed or statically linked"
@@ -32,7 +31,7 @@ module ZMQ
         warn "For non-Windows platforms, make sure libzmq is located in this search path:"
         warn ZMQ_LIB_PATHS.inspect
       end
-      raise LoadError, "The libzmq library (or DLL) could not be loaded"
+      raise LoadError, e.message
     end
     # Size_t not working properly on Windows
     find_type(:size_t) rescue typedef(:ulong, :size_t)


### PR DESCRIPTION
This change is consist of  two parts.
1. The first one is about error message in case of `LoadError`.
   
   When I tried to figure out #96 I hadn't chance to understand what's going on. 
   
   The message of LoadError exception is really long, but have full view of discovery process. 
   
   I think it would be great if people will see full story of discovery process.
2. The second one is about double `map` execution.
