### PR TITLE
support libzmq 4.0

### DIFF
--- a/lib/ffi-rzmq/constants.rb
+++ b/lib/ffi-rzmq/constants.rb
@@ -123,7 +123,7 @@ if ZMQ::LibZMQ.version2?
 end # version2?
 
 
-if ZMQ::LibZMQ.version3?
+if ZMQ::LibZMQ.version3? || ZMQ::LibZMQ.version4?
   module ZMQ
     # Socket types
     XPUB = 9
@@ -184,4 +184,4 @@ if ZMQ::LibZMQ.version3?
     # Socket & other errors
     EMFILE = Errno::EMFILE::Errno
   end
-end # version3?
+end # version3? || version4?

--- a/lib/ffi-rzmq/context.rb
+++ b/lib/ffi-rzmq/context.rb
@@ -59,7 +59,7 @@ module ZMQ
 
         define_finalizer
       end
-    elsif LibZMQ.version3?
+    elsif LibZMQ.version3? || LibZMQ.version4?
 
       def self.create(opts = {})
         new(opts) rescue nil

--- a/lib/ffi-rzmq/libzmq.rb
+++ b/lib/ffi-rzmq/libzmq.rb
@@ -71,6 +71,8 @@ module ZMQ
 
     def self.version3?() version[:major] == 3 && version[:minor] >= 2 end
 
+    def self.version4?() version[:major] == 4 end
+
     # Context initialization and destruction
     @blocking = true
     attach_function :zmq_init, [:int], :pointer
@@ -274,7 +276,7 @@ module ZMQ
   # Sanity check; print an error and exit if we are trying to load an unsupported
   # version of libzmq.
   #
-  unless LibZMQ.version2? || LibZMQ.version3?
+  unless LibZMQ.version2? || LibZMQ.version3? || LibZMQ.version4?
     hash = LibZMQ.version
     version = "#{hash[:major]}.#{hash[:minor]}.#{hash[:patch]}"
     raise LoadError, "The libzmq version #{version} is incompatible with ffi-rzmq."

--- a/lib/ffi-rzmq/message.rb
+++ b/lib/ffi-rzmq/message.rb
@@ -199,7 +199,7 @@ module ZMQ
 
   end # class Message
   
-  if LibZMQ.version3?
+  if LibZMQ.version3? || LibZMQ.version4?
     class Message
       # Version3 only
       #

--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -646,7 +646,7 @@ module ZMQ
   end # LibZMQ.version2?
 
 
-  if LibZMQ.version3?
+  if LibZMQ.version3? || LibZMQ.version4?
     class Socket
       include CommonSocketBehavior
       include IdentitySupport
@@ -756,6 +756,6 @@ module ZMQ
         Proc.new { LibZMQ.zmq_close socket if Process.pid == pid }
       end
     end # Socket for version3
-  end # LibZMQ.version3?
+  end # LibZMQ.version3? || LibZMQ.version4?
 
 end # module ZMQ

--- a/lib/ffi-rzmq/util.rb
+++ b/lib/ffi-rzmq/util.rb
@@ -108,7 +108,7 @@ module ZMQ
         ['zmq_msg_init', 'zmq_msg_init_data', 'zmq_msg_copy', 'zmq_msg_move'].include?(source)
       end
       
-    elsif LibZMQ.version3?
+    elsif LibZMQ.version3? || LibZMQ.version4?
       def self.context_error?(source)
         'zmq_ctx_new' == source ||
         'zmq_ctx_set' == source ||


### PR DESCRIPTION
this doesn't add any support for new features, but it does allow 4.0 to work, since it is compatible with 3.2.
