### PR TITLE
Add ZeroMQ 4 constants

### DIFF
--- a/lib/ffi-rzmq/constants.rb
+++ b/lib/ffi-rzmq/constants.rb
@@ -185,3 +185,35 @@ if ZMQ::LibZMQ.version3? || ZMQ::LibZMQ.version4?
     EMFILE = Errno::EMFILE::Errno
   end
 end # version3? || version4?
+
+if ZMQ::LibZMQ.version4?
+  module ZMQ
+    # Socket types
+    STREAM = 11
+
+    # Socket Options
+    IPV6 = 42
+    MECHANISM = 43
+    PLAIN_SERVER = 44
+    PLAIN_USERNAME = 45
+    PLAIN_PASSWORD = 46
+    CURVE_SERVER = 47
+    CURVE_PUBLICKEY = 48
+    CURVE_SECRETKEY = 49
+    CURVE_SERVERKEY = 50
+    PROBE_ROUTER = 51
+    REQ_CORRELATE = 52
+    REQ_RELAXED = 53
+    CONFLATE = 54
+    ZAP_DOMAIN = 55
+
+    # Socket Security Types
+    NULL = 0
+    PLAIN = 1
+    CURVE = 2
+
+    # Socket monitoring
+    EVENT_MONITOR_STOPPED = 1024
+    EVENT_ALL |= EVENT_MONITOR_STOPPED
+  end
+end

--- a/lib/ffi-rzmq/context.rb
+++ b/lib/ffi-rzmq/context.rb
@@ -105,7 +105,7 @@ module ZMQ
           0
         end
       end
-    elsif LibZMQ.version3?
+    elsif LibZMQ.version3? || LibZMQ.version4?
       def terminate
         unless @context.nil? || @context.null?
           remove_finalizer

--- a/lib/ffi-rzmq/socket.rb
+++ b/lib/ffi-rzmq/socket.rb
@@ -739,6 +739,14 @@ module ZMQ
 
         # string options
         [LAST_ENDPOINT].each { |option| @option_lookup[option] = 2 }
+
+        if LibZMQ.version4?
+          [IPV6, MECHANISM, PLAIN_SERVER, CURVE_SERVER, PROBE_ROUTER,
+           REQ_CORRELATE, REQ_RELAXED, CONFLATE].each { |option| @option_lookup[option] = 0 }
+
+          [ ZAP_DOMAIN, PLAIN_USERNAME, PLAIN_PASSWORD,
+            CURVE_PUBLICKEY, CURVE_SERVERKEY, CURVE_SECRETKEY].each { |option| @option_lookup[option] = 2 }
+        end
       end
 
       # these finalizer-related methods cannot live in the CommonSocketBehavior

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ def version3?
   ZMQ::LibZMQ.version3?
 end
 
+def version4?
+  ZMQ::LibZMQ.version4?
+end
+
 def jruby?
   RUBY_PLATFORM =~ /java/
 end


### PR DESCRIPTION
Doing this as a PR to see if I've followed how you'd like this done Chuck. This adds all the new constants in ZeroMQ 4. Currently requires zeromq4 built with libsodium (which you can build via homebrew through my PR https://github.com/mxcl/homebrew/pull/23180).
