### PR TITLE
Uncaught exception: undefined method >=' for nil:NilClass ~/.rvm/gems…

### DIFF
--- a/lib/ffi-rzmq/context.rb
+++ b/lib/ffi-rzmq/context.rb
@@ -84,9 +84,7 @@ module ZMQ
         remove_finalizer
         rc = LibZMQ.zmq_ctx_term(@context)
         @context = nil
-        rc
-      else
-        0
+        rc || 0
       end
     end
 

--- a/lib/ffi-rzmq/context.rb
+++ b/lib/ffi-rzmq/context.rb
@@ -85,6 +85,8 @@ module ZMQ
         rc = LibZMQ.zmq_ctx_term(@context)
         @context = nil
         rc || 0
+      else
+        0
       end
     end
 


### PR DESCRIPTION
…/ruby-2.3.1/gems/ffi-rzmq-2.0.5/lib/ffi-rzmq/util.rb:33:inresultcode_ok?'

~/.rvm/gems/ruby-2.3.1/gems/zss-0.3.4/lib/zss/socket.rb:95:in check!' ~/.rvm/gems/ruby-2.3.1/gems/zss-0.3.4/lib/zss/socket.rb:55:incontext'
~/.rvm/gems/ruby-2.3.1/gems/zss-0.3.4/lib/zss/socket.rb:26:in call' ~/.rvm/gems/ruby-2.3.1/gems/zss-0.3.4/lib/zss/client.rb:36:incall'
~/.rvm/gems/ruby-2.3.1/gems/zss-0.3.4/lib/zss/client.rb:55:in method_missing' ~/ruby_microservice_test/zmq-service-suite-ruby-bootstrap/bin/zss-client:15:in<top (required)>'