### PR TITLE
use b.put_bytes instead of b.write_string for ffi 1.14.0 compatibility

### DIFF
--- a/lib/ffi-rzmq/message.rb
+++ b/lib/ffi-rzmq/message.rb
@@ -126,7 +126,7 @@ module ZMQ
     def copy_in_bytes bytes, len
       data_buffer = LibC.malloc len
       # writes the exact number of bytes, no null byte to terminate string
-      data_buffer.write_string bytes, len
+      data_buffer.put_bytes 0, bytes, 0, len
 
       # use libC to call free on the data buffer; earlier versions used an
       # FFI::Function here that called back into Ruby, but Rubinius won't


### PR DESCRIPTION
The semantics of write_string was changed in ffi 1.14.0 to add a NULL byte at the end of the target buffer. This causes buffer overflows in all programs that relied on the old semantics.

This patch fixes the problem by using the underlying b.put_bytes method.