### PR TITLE
Add ostruct into gemspec

### DIFF
--- a/ffi-rzmq.gemspec
+++ b/ffi-rzmq.gemspec
@@ -22,6 +22,7 @@ and run by any ruby runtime that supports FFI. That's all of the major ones - MR
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "ffi-rzmq-core", [">= 1.0.7"]
+  s.add_runtime_dependency "ostruct"
   s.add_development_dependency "rspec", ["~> 3.7"]
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
With ruby `3.3.5` some gems are extracted from standard library. Therefore we get warning to migrate them into gemfile/gemspec. 

```
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of ffi-rzmq-2.0.7 to request adding ostruct into its gemspec.
```

PR to fix the issue: https://github.com/chuckremes/ffi-rzmq/issues/135