### PR TITLE
Fix typo in context error check method

### DIFF
--- a/lib/ffi-rzmq/util.rb
+++ b/lib/ffi-rzmq/util.rb
@@ -106,7 +106,7 @@ module ZMQ
       'zmq_ctx_new' == source ||
         'zmq_ctx_set' == source ||
         'zmq_ctx_get' == source ||
-        'zmq_ctx_destory' == source ||
+        'zmq_ctx_destroy' == source ||
         'zmq_ctx_set_monitor' == source
     end
 


### PR DESCRIPTION
This is simply a typo correction.